### PR TITLE
Remove mathn dependency

### DIFF
--- a/lib/geometry/annulus.rb
+++ b/lib/geometry/annulus.rb
@@ -1,7 +1,7 @@
 module Geometry
 
 =begin rdoc
-An {http://en.wikipedia.org/wiki/Annulus_(mathematics) Annulus}, more commonly
+An {http://en.wikipedia.org/wiki/Annulus_(mathematics) Annulus}, more commonly 
 known as a Ring, is a circle that ate another circle.
 
 == Usage

--- a/lib/geometry/annulus.rb
+++ b/lib/geometry/annulus.rb
@@ -1,7 +1,7 @@
 module Geometry
 
 =begin rdoc
-An {http://en.wikipedia.org/wiki/Annulus_(mathematics) Annulus}, more commonly 
+An {http://en.wikipedia.org/wiki/Annulus_(mathematics) Annulus}, more commonly
 known as a Ring, is a circle that ate another circle.
 
 == Usage
@@ -22,7 +22,7 @@ known as a Ring, is a circle that ate another circle.
 	# @!attribute inner_radius
 	#   @return [Number]  the radius of the inside of the {Annulus}
 	def inner_radius
-	    @inner_radius || (@inner_diameter && @inner_diameter/2)
+	    @inner_radius || (@inner_diameter && @inner_diameter.to_r/2)
 	end
 
 	# @!attribute outer_diameter
@@ -34,7 +34,7 @@ known as a Ring, is a circle that ate another circle.
 	# @!attribute outer_radius
 	#   @return [Number]  the outer radius
 	def outer_radius
-	    @outer_radius || (@outer_diameter && @outer_diameter/2)
+	    @outer_radius || ((@outer_diameter && @outer_diameter).to_r/2)
 	end
 
 	# @!attribute diameter

--- a/lib/geometry/edge.rb
+++ b/lib/geometry/edge.rb
@@ -1,5 +1,3 @@
-require 'mathn'
-
 require_relative 'point'
 
 module Geometry
@@ -147,8 +145,8 @@ An edge. It's a line segment between 2 points. Generally part of a {Polygon}.
 		    nil
 		end
 	    else
-		s = (-v1[1] * p.x + v1[0] * p.y) / denominator	# v1 x (p0 - p2) / denominator
-		t = ( v2[0] * p.y - v2[1] * p.x) / denominator	# v2 x (p0 - p2) / denominator
+		s = (-v1[1] * p.x + v1[0] * p.y).to_r / denominator	# v1 x (p0 - p2) / denominator
+		t = ( v2[0] * p.y - v2[1] * p.x).to_r / denominator	# v2 x (p0 - p2) / denominator
 
 		p0 + v1 * t if ((0..1) === s) && ((0..1) === t)
 	    end

--- a/lib/geometry/rectangle.rb
+++ b/lib/geometry/rectangle.rb
@@ -112,7 +112,7 @@ The {Rectangle} class cluster represents your typical arrangement of 4 corners a
 	# @return [Point]   The {Rectangle}'s center
 	def center
 	    min, max = @points.minmax {|a,b| a.y <=> b.y}
-	    Point[(max.x+min.x)/2, (max.y+min.y)/2]
+	    Point[(max.x+min.x).to_r/2, (max.y+min.y).to_r/2]
 	end
 
 	# @!attribute closed?

--- a/test/geometry/circle.rb
+++ b/test/geometry/circle.rb
@@ -10,11 +10,11 @@ describe Geometry::Circle do
 	it "must create a Circle" do
 	    circle.must_be_instance_of(Circle)
 	end
-	
+
 	it "must have a center point accessor" do
 	    circle.center.must_equal Point[1,2]
 	end
-	
+
 	it "must have a radius accessor" do
 	    circle.radius.must_equal 3
 	end
@@ -26,15 +26,15 @@ describe Geometry::Circle do
 
     describe "when constructed with named center and radius arguments" do
 	let(:circle) { Circle.new :center => [1,2], :radius => 3 }
-	
+
 	it "must create a Circle" do
 	    circle.must_be_instance_of(Circle)
 	end
-	
+
 	it "must have a center point accessor" do
 	    circle.center.must_equal Point[1,2]
 	end
-	
+
 	it "must have a radius accessor" do
 	    circle.radius.must_equal 3
 	end
@@ -108,17 +108,17 @@ describe Geometry::Circle do
 	let(:circle) { Circle.new :diameter => Rational(5,3) }
 
 	it 'must have the correct min values' do
-	    circle.min.must_equal Point[-5/6, -5/6]
+	    circle.min.must_equal Point[-5.to_r/6, -5.to_r/6]
 	    circle.min.must_be_instance_of Geometry::PointIso
 	end
 
 	it 'must have the correct max values' do
-	    circle.max.must_equal Point[5/6, 5/6]
+	    circle.max.must_equal Point[5.to_r/6, 5.to_r/6]
 	    circle.max.must_be_instance_of Geometry::PointIso
 	end
 
 	it 'must have the correct minmax values' do
-	    circle.minmax.must_equal [Point[-5/6, -5/6], Point[5/6,5/6]]
+	    circle.minmax.must_equal [Point[-5.to_r/6, -5.to_r/6], Point[5.to_r/6,5.to_r/6]]
 	end
     end
 

--- a/test/geometry/circle.rb
+++ b/test/geometry/circle.rb
@@ -10,11 +10,11 @@ describe Geometry::Circle do
 	it "must create a Circle" do
 	    circle.must_be_instance_of(Circle)
 	end
-
+	
 	it "must have a center point accessor" do
 	    circle.center.must_equal Point[1,2]
 	end
-
+	
 	it "must have a radius accessor" do
 	    circle.radius.must_equal 3
 	end
@@ -26,15 +26,15 @@ describe Geometry::Circle do
 
     describe "when constructed with named center and radius arguments" do
 	let(:circle) { Circle.new :center => [1,2], :radius => 3 }
-
+	
 	it "must create a Circle" do
 	    circle.must_be_instance_of(Circle)
 	end
-
+	
 	it "must have a center point accessor" do
 	    circle.center.must_equal Point[1,2]
 	end
-
+	
 	it "must have a radius accessor" do
 	    circle.radius.must_equal 3
 	end


### PR DESCRIPTION
As `mathn` is deprecated and as it overwrites basic math operations globally (which breaks applications written in ruby 5.1), I prepared this PR that removes `mathn` and relies on standard ruby methods. 

The tests for this PR break for Ruby 2.0. 
Please advise, if I should fix the tests for this version of ruby, or it's better to remove the support for version 2.0 (which is pretty old)